### PR TITLE
Return 0.0 if text is empty

### DIFF
--- a/gibberishclassifier.py
+++ b/gibberishclassifier.py
@@ -60,6 +60,8 @@ def deviation_score(percentage, lower_bound, upper_bound):
 
 
 def classify(text):
+    if len(text) == 0:
+        return 0.0
     ucpcp = unique_chars_per_chunk_percentage(text, 35)
     vp = vowels_percentage(text)
     wtcr = word_to_char_ratio(text)


### PR DESCRIPTION
There's still some divide by 0 errors when having text be empty. If we were to fix all of those, it would return 100.0 for an empty string, which I don't think would be useful.
